### PR TITLE
fix: skip unparseable JSON links in VoteExtractor instead of crashing

### DIFF
--- a/qhld_engine/extractors/spain/initiative_extractors/vote_extractor.py
+++ b/qhld_engine/extractors/spain/initiative_extractors/vote_extractor.py
@@ -14,6 +14,18 @@ from ..congress_api import CongressApi
 log = get_logger(__name__)
 
 
+def extract_json_link(html):
+    regex = re.compile(r'<a[\sa-zA-Z\"\.=0-9_\/:]+\>JSON\<\/a\>')
+    matches = regex.findall(html)
+    if not matches:
+        return None
+    tag = matches[0]
+    start = tag.find('href="') + 6
+    link = tag[start:]
+    end = link.find('"')
+    return link[:end]
+
+
 class VoteExtractor():
     JSON_XPATH = "//div[@class='votaciones']/div[1]/a[contains(text(), 'JSON')]"
     VOTE_TYPES = [
@@ -42,8 +54,11 @@ class VoteExtractor():
                     self.__extract_item(item, 'Principal')
 
     def __extract_item(self, item, label):
+        link = extract_json_link(item)
+        if link is None:
+            log.warning(f"No JSON link found for {self.reference}")
+            return
         log.info(f"Extracting '{label}' votes for {self.reference}")
-        link = self.extract_link(item)
         self.extract_votes(link)
 
     def get_votes_html(self):
@@ -62,15 +77,6 @@ class VoteExtractor():
             cleaned.append(unescape(item) + 'JSON</a>')
 
         return cleaned[:len(cleaned) - 1]
-
-    def extract_link(self, html):
-        regex = re.compile(r'<a[\sa-zA-Z\"\.=0-9_\/:]+\>JSON\<\/a\>')
-        matches = regex.findall(html)
-        tag = matches[0]
-        start = tag.find('href="') + 6
-        link = tag[start:]
-        end = link.find('"')
-        return link[:end]
 
     def extract_votes(self, url):
         try:

--- a/tests/unit/test_vote_extractor.py
+++ b/tests/unit/test_vote_extractor.py
@@ -1,0 +1,15 @@
+import pytest
+
+from qhld_engine.extractors.spain.initiative_extractors.vote_extractor import extract_json_link
+
+pytestmark = pytest.mark.unit
+
+
+def test_extract_json_link_returns_none_for_unparseable_querystring_href():
+    href = "https://www.congreso.es/opendata/votaciones?targetDate=24/09/2024&targetLegislatura=XV"
+    assert extract_json_link(f'<a href="{href}">JSON</a>') is None
+
+
+def test_extract_json_link_parses_clean_json_href():
+    href = "https://www.congreso.es/webpublica/opendata/votaciones/Leg15/Sesion061/20240924/Votacion001/VOT_20240924203510.json"
+    assert extract_json_link(f'<a href="{href}" download="">JSON</a>') == href


### PR DESCRIPTION
El VoteExtractor reventaba con IndexError al toparse con un enlace JSON de href inparseable (URL de portal con query-string, que congreso.es sirve), abortando la extracción de votos de la iniciativa. Este fix hace que se salte esos enlaces en vez de reventar.