### PR TITLE
chore: update pdfminer.six to 20260107 (fixes CVE-2025-64512, CVE-2025-70559)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "beautifulsoup4==4.12.3",
     "cssselect==1.2.0",
     "pdf2image==1.17.0",
-    "pdfminer.six==20240706",
+    "pdfminer.six==20260107",
     "pydantic-settings==2.14.2",
     "pytesseract==0.3.13",
     "python-docx==1.1.2",

--- a/tests/unit/test_pdf_parsers.py
+++ b/tests/unit/test_pdf_parsers.py
@@ -1,0 +1,48 @@
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from qhld_engine.extractors.spain.initiative_extractors.utils import pdf_parsers
+from qhld_engine.extractors.spain.initiative_extractors.utils.pdf_parsers import (
+    PDFParser,
+)
+
+pytestmark = pytest.mark.unit
+
+_STREAM = (
+    b"BT /F1 18 Tf 72 720 Td (Proyecto de Ley 12/2024) Tj "
+    b"0 -28 Td (Comision de Justicia) Tj ET"
+)
+SAMPLE_PDF = (
+    b"%PDF-1.4\n"
+    b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+    b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+    b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+    b"/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj\n"
+    b"4 0 obj<</Length " + str(len(_STREAM)).encode() + b">>stream\n"
+    + _STREAM + b"\nendstream endobj\n"
+    b"5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj\n"
+    b"trailer<</Root 1 0 R/Size 6>>\n%%EOF"
+)
+
+
+def test_extract_returns_text_lines_from_real_pdf():
+    lines = PDFParser(SimpleNamespace(name=BytesIO(SAMPLE_PDF))).extract()
+
+    assert "Proyecto de Ley 12/2024" in lines
+    assert "Comision de Justicia" in lines
+
+
+def test_extract_postprocesses_form_feed_tabs_and_newlines():
+    raw = "  Titulo\fSegunda\tpagina\nTercera  "
+
+    with patch.object(pdf_parsers, "extract_text", return_value=raw):
+        result = PDFParser(SimpleNamespace(name=None)).extract()
+
+    assert result == ["Titulo Segundapagina", "Tercera"]
+
+
+def test_extract_returns_empty_list_when_extraction_fails():
+    assert PDFParser(SimpleNamespace(name=BytesIO(b"not a pdf"))).extract() == []

--- a/uv.lock
+++ b/uv.lock
@@ -701,15 +701,15 @@ wheels = [
 
 [[package]]
 name = "pdfminer-six"
-version = "20240706"
+version = "20260107"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charset-normalizer" },
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/37/63cb918ffa21412dd5d54e32e190e69bfc340f3d6aa072ad740bec9386bb/pdfminer.six-20240706.tar.gz", hash = "sha256:c631a46d5da957a9ffe4460c5dce21e8431dabb615fee5f9f4400603a58d95a6", size = 7363505, upload-time = "2024-07-06T13:48:50.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/a4/5cec1112009f0439a5ca6afa8ace321f0ab2f48da3255b7a1c8953014670/pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602", size = 8512094, upload-time = "2026-01-07T13:29:12.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/7d/44d6b90e5a293d3a975cefdc4e12a932ebba814995b2a07e37e599dd27c6/pdfminer.six-20240706-py3-none-any.whl", hash = "sha256:f4f70e74174b4b3542fcb8406a210b6e2e27cd0f0b5fd04534a8cc0d8951e38c", size = 5615414, upload-time = "2024-07-06T13:48:48.408Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8b/28c4eaec9d6b036a52cb44720408f26b1a143ca9bce76cc19e8f5de00ab4/pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9", size = 6592252, upload-time = "2026-01-07T13:29:10.742Z" },
 ]
 
 [[package]]
@@ -1186,7 +1186,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.12.3" },
     { name = "cssselect", specifier = "==1.2.0" },
     { name = "pdf2image", specifier = "==1.17.0" },
-    { name = "pdfminer-six", specifier = "==20240706" },
+    { name = "pdfminer-six", specifier = "==20260107" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
     { name = "pytesseract", specifier = "==0.3.13" },
     { name = "python-docx", specifier = "==1.1.2" },


### PR DESCRIPTION
Actualiza `pdfminer.six` (`20240706` → `20260107`) para cerrar dos CVE (CVE-2025-64512 y CVE-2025-70559). Aunque solo leemos PDFs del Congreso, no está de más actualizar.

Nota: deja `qhld-tasks` sin tocar; mergear después de #101 para dejar el lock consistente.